### PR TITLE
E2e tests

### DIFF
--- a/.github/workflows/e2e-live.yml
+++ b/.github/workflows/e2e-live.yml
@@ -19,6 +19,8 @@ jobs:
   e2e:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    # workflow_run carries no inputs — defaults to 'prod', which is correct:
+    # deploy.yml only ever deploys to prod on push to main.
     environment: ${{ inputs.environment || 'prod' }}
 
     env:

--- a/.github/workflows/e2e-live.yml
+++ b/.github/workflows/e2e-live.yml
@@ -1,0 +1,103 @@
+name: E2E Tests (live)
+
+on:
+  workflow_run:
+    workflows: [ "Build, Test and Deploy" ]
+    types: [ completed ]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Deployment environment
+        required: true
+        type: environment
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  e2e:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment || 'prod' }}
+
+    env:
+      STAGE: ${{ inputs.environment || 'prod' }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .tool-versions
+          cache: npm
+          cache-dependency-path: e2e/package-lock.json
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Discover CloudFront distribution URL
+        id: discover
+        run: |
+          DIST_ARN=$(aws resourcegroupstaggingapi get-resources \
+            --tag-filters Key=app,Values=pokerdot Key=stage,Values=${STAGE} Key=resource,Values=cdn \
+            --resource-type-filters cloudfront:distribution \
+            --query 'ResourceTagMappingList[0].ResourceARN' \
+            --region us-east-1 \
+            --output text)
+          if [ "$DIST_ARN" = "None" ] || [ -z "$DIST_ARN" ]; then
+            echo "::error::Failed to discover CloudFront distribution for stage ${STAGE}"
+            exit 1
+          fi
+          DIST_ID=$(echo "$DIST_ARN" | awk -F/ '{print $NF}')
+          echo "Discovered CloudFront distribution: ${DIST_ID}"
+
+          DOMAIN=$(aws cloudfront get-distribution \
+            --id "$DIST_ID" \
+            --query 'Distribution.DistributionConfig.Aliases.Items[0]' \
+            --output text)
+          if [ "$DOMAIN" = "None" ] || [ -z "$DOMAIN" ]; then
+            echo "::error::No alias found on distribution ${DIST_ID}"
+            exit 1
+          fi
+          BASE_URL="https://${DOMAIN}"
+          echo "base_url=${BASE_URL}" >> "$GITHUB_OUTPUT"
+          echo "Target: ${BASE_URL}"
+
+      - name: Install e2e dependencies
+        working-directory: e2e
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('e2e/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: e2e
+        run: npx playwright install --with-deps chromium webkit
+
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: e2e
+        run: npx playwright install-deps chromium webkit
+
+      - name: Run E2E tests
+        working-directory: e2e
+        run: npm test
+        env:
+          BASE_URL: ${{ steps.discover.outputs.base_url }}
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-report-${{ env.STAGE }}
+          path: e2e/playwright-report/
+          retention-days: 30

--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -29,6 +29,12 @@ jobs:
         working-directory: e2e
         run: npm ci
 
+      - name: Cache DynamoDB Local
+        uses: actions/cache@v4
+        with:
+          path: .dynamodb-local
+          key: dynamodb-local-${{ hashFiles('**.sbt', 'project/**.scala', 'project/build.properties') }}
+
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         id: playwright-cache

--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -1,0 +1,59 @@
+name: E2E Tests (local)
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .tool-versions
+          cache: npm
+          cache-dependency-path: |
+            frontend/package-lock.json
+            e2e/package-lock.json
+
+      - uses: guardian/setup-scala@v1
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install e2e dependencies
+        working-directory: e2e
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('e2e/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: e2e
+        run: npx playwright install --with-deps chromium webkit
+
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: e2e
+        run: npx playwright install-deps chromium webkit
+
+      - name: Run E2E tests
+        working-directory: e2e
+        run: npm test
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -293,3 +293,9 @@ project/plugins/project/
 *.class
 
 # End of https://www.toptal.com/developers/gitignore/api/emacs,intellij,elm,scala,sbt,node
+
+### E2E ###
+e2e/node_modules/
+e2e/playwright-report/
+e2e/test-results/
+e2e/.playwright/

--- a/cloudformation/pokerdot-storage.template.yaml
+++ b/cloudformation/pokerdot-storage.template.yaml
@@ -164,10 +164,11 @@ Resources:
                     aws:ResourceTag/app: pokerdot
                     aws:ResourceTag/stage: !Ref Stage
                     aws:ResourceTag/resource: backend
-              # Invalidate CloudFront distribution
+              # Invalidate and inspect CloudFront distribution
               - Effect: Allow
                 Action:
                   - cloudfront:CreateInvalidation
+                  - cloudfront:GetDistribution
                 Resource: !Sub "arn:aws:cloudfront::${AWS::AccountId}:distribution/*"
       Tags:
         - Key: "app"

--- a/devserver/src/main/scala/io/adamnfish/pokerdot/DevServer.scala
+++ b/devserver/src/main/scala/io/adamnfish/pokerdot/DevServer.scala
@@ -85,6 +85,13 @@ object CatsDevServer extends IOApp:
       app <- Resource.make {
         IO.blocking {
           Javalin.create { config =>
+            config.routes.get(
+              "/healthcheck",
+              { ctx =>
+                ctx.status(200)
+                ctx.result("OK")
+              }
+            )
             config.routes.ws(
               "/api",
               { ws =>

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,109 @@
+{
+  "name": "pokerdot-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pokerdot-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.48.0",
+        "@types/node": "^25.6.0",
+        "typescript": "^5.6.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pokerdot-e2e",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:local": "BASE_URL=http://localhost:3000 playwright test",
+    "test:live": "playwright test",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0",
+    "@types/node": "^25.6.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from '@playwright/test';
+
+const isLocal = !process.env.BASE_URL || process.env.BASE_URL.includes('localhost');
+
+export default defineConfig({
+  testDir: './tests',
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL: process.env.BASE_URL ?? 'http://localhost:3000',
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+  expect: {
+    timeout: 10_000,
+  },
+  webServer: isLocal
+    ? [
+        {
+          command: 'npm run start',
+          cwd: '../frontend',
+          url: 'http://localhost:3000',
+          reuseExistingServer: !process.env.CI,
+        },
+        {
+          command: 'sbt "devServer/run 0"',
+          cwd: '..',
+          url: 'http://localhost:7000/healthcheck',
+          reuseExistingServer: !process.env.CI,
+          timeout: 180_000,
+        },
+      ]
+    : [],
+});

--- a/e2e/tests/heads-up-fold-and-rejoin.spec.ts
+++ b/e2e/tests/heads-up-fold-and-rejoin.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect, devices } from '@playwright/test';
+import { createGame, joinGame, startGame, fold, getJoinCodeFromLink, snap, waitForWelcome } from './helpers';
+
+test.setTimeout(90_000);
+
+test('heads up fold and rejoin', async ({ browser }, testInfo) => {
+  const iphoneCtx = await browser.newContext({ ...devices['iPhone 15'] });
+  const androidCtx = await browser.newContext({ ...devices['Pixel 8'] });
+  const iphone = await iphoneCtx.newPage();
+  const android = await androidCtx.newPage();
+
+  try {
+    // --- Step 1: Alice creates the game ---
+    await waitForWelcome(iphone);
+    await snap(iphone, '01-iphone-welcome', testInfo);
+    await createGame(iphone, { gameName: 'E2E Test', playerName: 'Alice' });
+    await snap(iphone, '02-iphone-create-form', testInfo);
+
+    // Wait for lobby
+    await expect(iphone.getByRole('link', { name: /join link/i })).toBeVisible();
+    await snap(iphone, '03-iphone-lobby', testInfo);
+
+    const gameCode = await getJoinCodeFromLink(iphone);
+
+    // --- Step 2: Bob joins via game code ---
+    await waitForWelcome(android);
+    await snap(android, '04-android-welcome', testInfo);
+    await joinGame(android, { gameCode, playerName: 'Bob' });
+    await snap(android, '05-android-join-form', testInfo);
+
+    // Wait for Bob's lobby
+    await expect(android.getByRole('button', { name: /start/i })).not.toBeVisible();
+    await snap(android, '06-android-lobby', testInfo);
+
+    // --- Step 3: Alice starts the game ---
+    await startGame(iphone);
+    await snap(iphone, '07-iphone-game-start', testInfo);
+
+    // --- Step 4: Bob's game screen ---
+    // Wait for Bob to reach the game screen; he may or may not be first to act
+    await expect(android.getByText('Bob').first()).toBeVisible({ timeout: 15_000 });
+    await snap(android, '08-android-game-start', testInfo);
+
+    // --- Step 5: Whoever acts first folds ---
+    const iphoneFoldVisible = await iphone.getByRole('button', { name: /fold/i }).isVisible();
+    const androidFoldVisible = await android.getByRole('button', { name: /fold/i }).isVisible();
+
+    if (iphoneFoldVisible) {
+      await snap(iphone, '09-iphone-pre-fold', testInfo);
+      await fold(iphone);
+      await snap(iphone, '10-iphone-folded', testInfo);
+    } else if (androidFoldVisible) {
+      await snap(android, '09-android-pre-fold', testInfo);
+      await fold(android);
+      await snap(android, '10-android-folded', testInfo);
+    } else {
+      throw new Error('Neither player has the fold button — cannot determine who acts first');
+    }
+
+    // --- Step 6: Both see round advance ---
+    // Allow time for the round result flash and next hand deal
+    await iphone.waitForTimeout(1_000);
+    await snap(iphone, '11-iphone-next-hand', testInfo);
+    await snap(android, '12-android-next-hand', testInfo);
+
+    // --- Step 7: Bob navigates home (simulates returning via home button) ---
+    // goto('/') exercises the library/rejoin flow; reload() would reconnect directly at /#game/…
+    await android.goto('/');
+    await expect(android.getByRole('button', { name: /E2E Test/i })).toBeVisible({ timeout: 10_000 });
+    await snap(android, '13-android-welcome-with-library', testInfo);
+
+    // --- Step 8: Bob rejoins ---
+    await android.getByRole('button', { name: /E2E Test/i }).click();
+    // After rejoin: game may be in any state — deal/peek (between hands), fold/call (active round)
+    await expect(
+      android.getByRole('button', { name: /deal/i })
+        .or(android.getByRole('button', { name: /peek/i }))
+        .or(android.getByRole('button', { name: /fold/i }))
+    ).toBeVisible({ timeout: 15_000 });
+    await snap(android, '14-android-rejoined', testInfo);
+
+    // --- Step 9: Alice still sees Bob in the game ---
+    await snap(iphone, '15-iphone-after-rejoin', testInfo);
+    await expect(iphone.getByText(/Bob/i).first()).toBeVisible();
+  } finally {
+    await iphoneCtx.close();
+    await androidCtx.close();
+  }
+});

--- a/e2e/tests/heads-up-fold-and-rejoin.spec.ts
+++ b/e2e/tests/heads-up-fold-and-rejoin.spec.ts
@@ -28,8 +28,8 @@ test('heads up fold and rejoin', async ({ browser }, testInfo) => {
     await joinGame(android, { gameCode, playerName: 'Bob' });
     await snap(android, '05-android-join-form', testInfo);
 
-    // Wait for Bob's lobby
-    await expect(android.getByRole('button', { name: /start/i })).not.toBeVisible();
+    // Wait for Bob's lobby — positive check that Alice is visible in the player list
+    await expect(android.getByText(/Alice/i).first()).toBeVisible();
     await snap(android, '06-android-lobby', testInfo);
 
     // --- Step 3: Alice starts the game ---

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -1,0 +1,51 @@
+import { Page, TestInfo } from '@playwright/test';
+
+export async function waitForWelcome(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.getByRole('button', { name: /create.*game/i }).waitFor();
+}
+
+export async function createGame(
+  page: Page,
+  { gameName, playerName }: { gameName: string; playerName: string }
+): Promise<void> {
+  await page.goto('/');
+  await page.getByRole('button', { name: /create.*game/i }).click();
+  await page.getByLabel(/game name/i).fill(gameName);
+  await page.getByLabel(/your name/i).fill(playerName);
+  await page.getByRole('button', { name: /create.*game/i }).click();
+}
+
+export async function joinGame(
+  page: Page,
+  { gameCode, playerName }: { gameCode: string; playerName: string }
+): Promise<void> {
+  await page.goto('/');
+  await page.getByRole('button', { name: /join.*game/i }).click();
+  await page.getByLabel(/game code/i).fill(gameCode);
+  await page.getByLabel(/your name/i).fill(playerName);
+  await page.getByRole('button', { name: /join.*game/i }).click();
+}
+
+export async function startGame(page: Page): Promise<void> {
+  // Uses form defaults for starting stack and small blind
+  await page.getByRole('button', { name: /start/i }).click();
+}
+
+export async function fold(page: Page): Promise<void> {
+  await page.getByRole('button', { name: /fold/i }).click();
+}
+
+export async function getJoinCodeFromLink(page: Page): Promise<string> {
+  // The host's share link has href="/#join/{gameCode}"
+  const href = await page.getByRole('link', { name: /join link/i }).getAttribute('href');
+  if (!href) throw new Error('Join link not found in lobby');
+  const match = href.match(/#join\/(.+)$/);
+  if (!match) throw new Error(`Unexpected join link format: ${href}`);
+  return match[1];
+}
+
+export async function snap(page: Page, name: string, testInfo: TestInfo): Promise<void> {
+  const buffer = await page.screenshot({ fullPage: true });
+  await testInfo.attach(name, { body: buffer, contentType: 'image/png' });
+}

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "noEmit": true
+  },
+  "include": ["tests/**/*.ts", "playwright.config.ts"]
+}


### PR DESCRIPTION
Add e2e tests that exercise the app.

These tests don't duplicate the game logic tests we already perform, but do a basic run-through of the app to make sure it works. These tests also collect screenshots throughout the journey, which is an easy way to manually check for visual regressions.

The tests can be run against the local dev-servers or against a real deployed environmemt. These allow us to both check changes locally (and in CI), and to do post-deploy checks of the application.

Mainly, this is so I can confidently merge dependabot updates without taking ages to check everything still works.

> This time won't you please
> Drive faster